### PR TITLE
Support to obtain bukkit permissions from bungee.

### DIFF
--- a/src/main/java/me/neznamy/tab/bridge/Main.java
+++ b/src/main/java/me/neznamy/tab/bridge/Main.java
@@ -92,6 +92,12 @@ public class Main extends JavaPlugin implements PluginMessageListener {
 			ByteArrayDataOutput out = ByteStreams.newDataOutput();
 			out.writeUTF("Attribute");
 			out.writeUTF(attribute);
+			if (attribute.startsWith("hasPermission:")) {
+				String permission = attribute.substring(attribute.indexOf(":") + 1);
+				out.writeUTF(player.hasPermission(permission)+"");
+				player.sendPluginMessage(this, CHANNEL_NAME, out.toByteArray());
+				return;
+			}
 			if (attribute.equals("invisible")) {
 				out.writeUTF(player.hasPotionEffect(PotionEffectType.INVISIBILITY)+"");
 				player.sendPluginMessage(this, CHANNEL_NAME, out.toByteArray());


### PR DESCRIPTION
Use the luckperms plugin to use TAB permission control in bungee mode, the permission must be controlled by bukkit
Otherwise, once the tab.group.xxx permissions are set, the entire server will spread, even if the permissions are set to the "server=" function of the luckperms plug-in, it is useless